### PR TITLE
Fetch sensor data

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Yet another [Home Assistant](https://www.home-assistant.io) component for [Natur
 - [ ] Switch
 - [ ] Light
 - [ ] TV
-- [ ] Others
-  - [ ] Fetch sensor data
+- [X] Others
+  - [X] Fetch sensor data
 
 Tested on Home Assistant Core 2021.3.3 on Docker
 

--- a/__init__.py
+++ b/__init__.py
@@ -126,3 +126,53 @@ class NatureRemoBase(Entity):
             "model": self._device["serial_number"],
             "sw_version": self._device["firmware_version"],
         }
+
+
+class NatureRemoDeviceBase(Entity):
+    """Nature Remo Device entity base class."""
+
+    def __init__(self, coordinator, device):
+        self._coordinator = coordinator
+        self._name = f"Nature Remo {device['name']}"
+        self._device = device
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._device["id"]
+
+    @property
+    def should_poll(self):
+        """Return the polling requirement of the entity."""
+        return True
+
+    @property
+    def device_info(self):
+        """Return the device info for the sensor."""
+        # Since device registration requires Config Entries, this dosen't work for now
+        return {
+            "identifiers": {(DOMAIN, self._device["id"])},
+            "name": self._device["name"],
+            "manufacturer": "Nature Remo",
+            "model": self._device["serial_number"],
+            "sw_version": self._device["firmware_version"],
+        }
+
+    async def async_added_to_hass(self):
+        """Subscribe to updates."""
+        self.async_on_remove(
+            self._coordinator.async_add_listener(self.async_write_ha_state)
+        )
+
+    async def async_update(self):
+        """Update the entity.
+
+        Only used by the generic entity update service.
+        """
+        await self._coordinator.async_request_refresh()
+

--- a/climate.py
+++ b/climate.py
@@ -1,44 +1,34 @@
 """Support for Nature Remo AC."""
 import logging
 
-from homeassistant.core import callback
 from homeassistant.components.climate import ClimateEntity
-from homeassistant.components.climate.const import (
-    DEFAULT_MAX_TEMP,
-    DEFAULT_MIN_TEMP,
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_DRY,
-    HVAC_MODE_FAN_ONLY,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_OFF,
-    SUPPORT_FAN_MODE,
-    SUPPORT_SWING_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
-)
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
-from . import DOMAIN, CONF_COOL_TEMP, CONF_HEAT_TEMP, NatureRemoBase
+from homeassistant.components.climate.const import (ClimateEntityFeature,
+                                                    HVACMode)
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.core import callback
+
+from . import CONF_COOL_TEMP, CONF_HEAT_TEMP, DOMAIN, NatureRemoBase
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE
+SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.SWING_MODE | ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
 
 MODE_HA_TO_REMO = {
-    HVAC_MODE_AUTO: "auto",
-    HVAC_MODE_FAN_ONLY: "blow",
-    HVAC_MODE_COOL: "cool",
-    HVAC_MODE_DRY: "dry",
-    HVAC_MODE_HEAT: "warm",
-    HVAC_MODE_OFF: "power-off",
+    HVACMode.AUTO: "auto",
+    HVACMode.FAN_ONLY: "blow",
+    HVACMode.COOL: "cool",
+    HVACMode.DRY: "dry",
+    HVACMode.HEAT: "warm",
+    HVACMode.OFF: "power-off",
 }
 
 MODE_REMO_TO_HA = {
-    "auto": HVAC_MODE_AUTO,
-    "blow": HVAC_MODE_FAN_ONLY,
-    "cool": HVAC_MODE_COOL,
-    "dry": HVAC_MODE_DRY,
-    "warm": HVAC_MODE_HEAT,
-    "power-off": HVAC_MODE_OFF,
+    "auto": HVACMode.AUTO,
+    "blow": HVACMode.FAN_ONLY,
+    "cool": HVACMode.COOL,
+    "dry": HVACMode.DRY,
+    "warm": HVACMode.HEAT,
+    "power-off": HVACMode.OFF,
 }
 
 
@@ -62,13 +52,14 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 class NatureRemoAC(NatureRemoBase, ClimateEntity):
     """Implementation of a Nature Remo E sensor."""
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(self, coordinator, api, appliance, config):
         super().__init__(coordinator, appliance)
         self._api = api
         self._default_temp = {
-            HVAC_MODE_COOL: config[CONF_COOL_TEMP],
-            HVAC_MODE_HEAT: config[CONF_HEAT_TEMP],
+            HVACMode.COOL: config[CONF_COOL_TEMP],
+            HVACMode.HEAT: config[CONF_HEAT_TEMP],
         }
         self._modes = appliance["aircon"]["range"]["modes"]
         self._hvac_mode = None
@@ -93,7 +84,7 @@ class NatureRemoAC(NatureRemoBase, ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement which this thermostat uses."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def min_temp(self):
@@ -138,7 +129,7 @@ class NatureRemoAC(NatureRemoBase, ClimateEntity):
         """Return the list of available operation modes."""
         remo_modes = list(self._modes.keys())
         ha_modes = list(map(lambda mode: MODE_REMO_TO_HA[mode], remo_modes))
-        ha_modes.append(HVAC_MODE_OFF)
+        ha_modes.append(HVACMode.OFF)
         return ha_modes
 
     @property
@@ -167,6 +158,19 @@ class NatureRemoAC(NatureRemoBase, ClimateEntity):
         return {
             "previous_target_temperature": self._last_target_temperature,
         }
+    
+    async def async_turn_off(self):
+        """Turn the entity off."""
+        await self.async_set_hvac_mode(HVACMode.OFF)
+
+
+    async def async_turn_on(self):
+        """Turn the entity on."""
+        if self._remo_mode is None:
+            # if the mode is unknown, set to the default mode
+            await self.async_set_hvac_mode(HVACMode.COOL)
+        else:
+            await self.async_set_hvac_mode(MODE_REMO_TO_HA[self._remo_mode])
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
@@ -183,7 +187,7 @@ class NatureRemoAC(NatureRemoBase, ClimateEntity):
         """Set new target hvac mode."""
         _LOGGER.debug("Set hvac mode: %s", hvac_mode)
         mode = MODE_HA_TO_REMO[hvac_mode]
-        if mode == MODE_HA_TO_REMO[HVAC_MODE_OFF]:
+        if mode == MODE_HA_TO_REMO[HVACMode.OFF]:
             await self._post({"button": mode})
         else:
             data = {"operation_mode": mode}
@@ -225,8 +229,8 @@ class NatureRemoAC(NatureRemoBase, ClimateEntity):
         except:
             self._target_temperature = None
 
-        if ac_settings["button"] == MODE_HA_TO_REMO[HVAC_MODE_OFF]:
-            self._hvac_mode = HVAC_MODE_OFF
+        if ac_settings["button"] == MODE_HA_TO_REMO[HVACMode.OFF]:
+            self._hvac_mode = HVACMode.OFF
         else:
             self._hvac_mode = MODE_REMO_TO_HA[self._remo_mode]
 

--- a/sensor.py
+++ b/sensor.py
@@ -32,9 +32,13 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         if appliance["type"] == "EL_SMART_METER"
     ]
     for device in devices.values():
-        entities.append(NatureRemoTemperatureSensor(coordinator, device))
-        entities.append(NatureRemoHumiditySensor(coordinator, device))
-        entities.append(NatureRemoIlluminanceSensor(coordinator, device))
+        for sensor in device["newest_events"].keys():
+            if sensor == "te":
+                entities.append(NatureRemoTemperatureSensor(coordinator, device))
+            elif sensor == "hu":
+                entities.append(NatureRemoHumiditySensor(coordinator, device))
+            elif sensor == "li":
+                entities.append(NatureRemoIlluminanceSensor(coordinator, device))
     async_add_entities(entities)
 
 

--- a/sensor.py
+++ b/sensor.py
@@ -37,7 +37,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 entities.append(NatureRemoTemperatureSensor(coordinator, device))
             elif sensor == "hu":
                 entities.append(NatureRemoHumiditySensor(coordinator, device))
-            elif sensor == "li":
+            elif sensor == "il":
                 entities.append(NatureRemoIlluminanceSensor(coordinator, device))
     async_add_entities(entities)
 

--- a/sensor.py
+++ b/sensor.py
@@ -6,8 +6,14 @@ from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
     POWER_WATT,
     DEVICE_CLASS_POWER,
+    TEMP_CELSIUS,
+    DEVICE_CLASS_TEMPERATURE,
+    PERCENTAGE,
+    DEVICE_CLASS_HUMIDITY,
+    LIGHT_LUX,
+    DEVICE_CLASS_ILLUMINANCE,
 )
-from . import DOMAIN, NatureRemoBase
+from . import DOMAIN, NatureRemoBase, NatureRemoDeviceBase
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -19,13 +25,17 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     _LOGGER.debug("Setting up sensor platform.")
     coordinator = hass.data[DOMAIN]["coordinator"]
     appliances = coordinator.data["appliances"]
-    async_add_entities(
-        [
-            NatureRemoE(coordinator, appliance)
-            for appliance in appliances.values()
-            if appliance["type"] == "EL_SMART_METER"
-        ]
-    )
+    devices = coordinator.data["devices"]
+    entities = [
+        NatureRemoE(coordinator, appliance)
+        for appliance in appliances.values()
+        if appliance["type"] == "EL_SMART_METER"
+    ]
+    for device in devices.values():
+        entities.append(NatureRemoTemperatureSensor(coordinator, device))
+        entities.append(NatureRemoHumiditySensor(coordinator, device))
+        entities.append(NatureRemoIlluminanceSensor(coordinator, device))
+    async_add_entities(entities)
 
 
 class NatureRemoE(NatureRemoBase):
@@ -69,3 +79,90 @@ class NatureRemoE(NatureRemoBase):
         Only used by the generic entity update service.
         """
         await self._coordinator.async_request_refresh()
+
+
+class NatureRemoTemperatureSensor(NatureRemoDeviceBase):
+    """Implementation of a Nature Remo sensor."""
+
+    def __init__(self, coordinator, appliance):
+        super().__init__(coordinator, appliance)
+        self._name = self._name.strip() + " Temperature"
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._device["id"] + "-te"
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return TEMP_CELSIUS
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        device = self._coordinator.data["devices"][self._device["id"]]
+        return device["newest_events"]["te"]["val"]
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return DEVICE_CLASS_TEMPERATURE
+
+
+class NatureRemoHumiditySensor(NatureRemoDeviceBase):
+    """Implementation of a Nature Remo sensor."""
+
+    def __init__(self, coordinator, appliance):
+        super().__init__(coordinator, appliance)
+        self._name = self._name.strip() + " Humidity"
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._device["id"] + "-hu"
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return PERCENTAGE
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        device = self._coordinator.data["devices"][self._device["id"]]
+        return device["newest_events"]["hu"]["val"]
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return DEVICE_CLASS_HUMIDITY
+
+
+class NatureRemoIlluminanceSensor(NatureRemoDeviceBase):
+    """Implementation of a Nature Remo sensor."""
+
+    def __init__(self, coordinator, appliance):
+        super().__init__(coordinator, appliance)
+        self._name = self._name.strip() + " Illuminance"
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self._device["id"] + "-il"
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return LIGHT_LUX
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        device = self._coordinator.data["devices"][self._device["id"]]
+        return device["newest_events"]["il"]["val"]
+
+    @property
+    def device_class(self):
+        """Return the device class."""
+        return DEVICE_CLASS_ILLUMINANCE 


### PR DESCRIPTION
Add temperature, humidity, and illuminance sensors as 3 new separate entities.

This is my first time playing around with Home Assistant so I'm not sure how efficient my code is.
Most of the code is a direct modification from the Nature Remo E sensor.
Specifically, I'm not sure why we need the following method.

```
async def async_added_to_hass(self):
    """Subscribe to updates."""
    self.async_on_remove(
        self._coordinator.async_add_listener(self.async_write_ha_state)
    )
```

In any case, things seem to work...

Update (2025.05.09): Include https://github.com/yutoyazaki/hass-nature-remo/pull/19 in this PR.